### PR TITLE
Fix: automatically update the copyright year (closes #10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,16 +193,23 @@
     </section>
 
     <!-- Swiper JS -->
+    <footer>
+        <p>&copy; <span id="year"></span> Steph Ran. All Rights Reserved.</p>
+    </footer>
+    
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <script>
-        const swiper = new Swiper(".card-swiper", {
-        centeredSlides: false,
-        spaceBetween: 0,
-        slidesPerView: 'auto'
-    });
+        document.addEventListener("DOMContentLoaded", function () {
+            // Automatically update the copyright year
+            document.getElementById('year').textContent = new Date().getFullYear();
+    
+            // Initialize Swiper
+            const swiper = new Swiper(".card-swiper", {
+                centeredSlides: false,
+                spaceBetween: 0,
+                slidesPerView: 'auto'
+            });
+        });
     </script>
-</body>
-<footer>
-    <p>&copy; 2024 Steph Ran. All Rights Reserved.</p>
-</footer>
-</html>
+    </body>
+    </html>    


### PR DESCRIPTION
**PR Description: Automatically Update Copyright Year**
This PR introduces functionality to dynamically update the copyright year in the footer based on the current year using JavaScript. It ensures the displayed year is always accurate without manual updates.

**Changes Made:**

1. Added JavaScript logic to set the text content of the #year span to the current year (new Date().getFullYear()).
2. Wrapped the logic in a DOMContentLoaded event listener to ensure the DOM is fully loaded before the script executes.
3. Verified Swiper initialization remains unaffected by these changes.

**Issue Reference:**
Closes #10 
![Screenshot 2025-01-12 101058](https://github.com/user-attachments/assets/c6c0c489-84c2-4f20-8774-aa81b4745811)
